### PR TITLE
fix writing intermediate restart files for fv3 two phase run sequence

### DIFF
--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -1105,21 +1105,18 @@ module fv3gfs_cap_mod
 
     ! local variables
     character(len=*),parameter :: subname='(fv3gfs_cap:TimestampExport_phase1)'
-    type(ESMF_Clock)           :: modelClock
+    type(ESMF_Clock)           :: driverClock, modelClock
     type(ESMF_State)           :: exportState
 
     rc = ESMF_SUCCESS
 
     ! get driver and model clock
-    call NUOPC_ModelGet(gcomp, modelClock=modelClock, exportState=exportState, rc=rc)
+    call NUOPC_ModelGet(gcomp, driverClock=driverClock, &
+                        modelClock=modelClock, exportState=exportState, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
-    ! rewind clock by one time step
-    call ESMF_ClockSet(modelClock, direction=ESMF_DIRECTION_REVERSE, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    call ESMF_ClockAdvance(modelClock, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    call ESMF_ClockSet(modelClock, direction=ESMF_DIRECTION_FORWARD, rc=rc)
+    ! reset model clock to initial time
+    call NUOPC_CheckSetClock(modelClock, driverClock, forceCurrTime=.true., rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
     ! update timestamp on export Fields

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -86,7 +86,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
   integer                                         :: ngrids, mygrid
   integer,dimension(:),allocatable                :: grid_number_on_all_pets(:)
 
-  integer                     :: intrm_rst
+  integer                     :: intrm_rst, na
 
 !----- coupled model data -----
 
@@ -943,7 +943,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 !
 !***  local variables
 !
-      integer                    :: mype, na, seconds
+      integer                    :: mype, seconds
       real(kind=8)               :: mpi_wtime, tbeg1
 !
 !-----------------------------------------------------------------------
@@ -994,7 +994,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 !
 !***  local variables
 !
-      integer                    :: mype, na, date(6), seconds
+      integer                    :: mype, date(6), seconds
       character(len=64)          :: timestamp
       integer                    :: unit
       real(kind=8)               :: mpi_wtime, tbeg1
@@ -1022,8 +1022,6 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
       !--- intermediate restart
       if (intrm_rst>0) then
-        call get_time(Atmos%Time - Atmos%Time_init, seconds)
-        na = seconds/dt_atmos - 1
         if (ANY(frestart(:) == seconds)) then
           if (mype == 0) write(*,*)'write out restart at na=',na,' seconds=',seconds,  &
                                    'integration length=',na*dt_atmos/3600.

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -1037,6 +1037,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
       !--- intermediate restart
       if (intrm_rst>0) then
         call get_time(Atmos%Time - Atmos%Time_init, seconds)
+        na = seconds/dt_atmos - 1
         if (ANY(frestart(:) == seconds)) then
           if (mype == 0) write(*,*)'write out restart at na=',na,' seconds=',seconds,  &
                                    'integration lenght=',na*dt_atmos/3600.

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -1022,6 +1022,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
       !--- intermediate restart
       if (intrm_rst>0) then
+        call get_time(Atmos%Time - Atmos%Time_init, seconds)
         if (ANY(frestart(:) == seconds)) then
           if (mype == 0) write(*,*)'write out restart at na=',na,' seconds=',seconds,  &
                                    'integration length=',na*dt_atmos/3600.


### PR DESCRIPTION
## Description

This is to fix the restart file issue when fv3 is running with two phases. It removes the dependency on the number of time step obtained from the advanceCount in ESMF clockget call. farray now only contains the intermediate restart writing time. The logical variable restart_endfcst is to control if writing restart files at the end of forecast. There is also minor cleanup.

The code has been tested with both two phases and one phase atm run and with different configurations of restart_interval. 

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes https://github.com/NOAA-EMC/fv3atm/issues/488


## Testing

How were these changes tested? 
Tested on orion with two phases restart test.

What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
